### PR TITLE
Fix exception: java.lang.RuntimeException Methods marked with @UiThre…

### DIFF
--- a/android/src/main/java/id/nizwar/screen_capture_event/ScreenCaptureEventPlugin.java
+++ b/android/src/main/java/id/nizwar/screen_capture_event/ScreenCaptureEventPlugin.java
@@ -96,7 +96,9 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
                                                 setScreenRecordStatus(true);
                                                 updateScreenRecordStatus();
                                             } else if (mime.contains("image")) {
-                                                channel.invokeMethod("screenshot", file.getPath());
+                                                handler.post(() -> {
+                                                    channel.invokeMethod("screenshot", file.getPath());
+                                                });
                                             }
                                         }
                                     }
@@ -120,7 +122,9 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
                                                 setScreenRecordStatus(true);
                                                 updateScreenRecordStatus();
                                             } else if (mime.contains("image")) {
-                                                channel.invokeMethod("screenshot", file.getPath());
+                                                handler.post(() -> {
+                                                    channel.invokeMethod("screenshot", file.getPath());
+                                                });
                                             }
                                         }
                                     }


### PR DESCRIPTION
```
E/FileObserver(13147): Unhandled exception in FileObserver id.nizwar.screen_capture_event.ScreenCaptureEventPlugin$1@46ec1a
E/FileObserver(13147): java.lang.RuntimeException: Methods marked with @UiThread must be executed on the main thread. Current thread: FileObserver
E/FileObserver(13147): 	at io.flutter.embedding.engine.FlutterJNI.ensureRunningOnMainThread(FlutterJNI.java:1415)
E/FileObserver(13147): 	at io.flutter.embedding.engine.FlutterJNI.dispatchPlatformMessage(FlutterJNI.java:1036)
E/FileObserver(13147): 	at io.flutter.embedding.engine.dart.DartMessenger.send(DartMessenger.java:282)
E/FileObserver(13147): 	at io.flutter.embedding.engine.dart.DartExecutor$DefaultBinaryMessenger.send(DartExecutor.java:470)
E/FileObserver(13147): 	at io.flutter.embedding.engine.dart.DartExecutor.send(DartExecutor.java:223)
E/FileObserver(13147): 	at io.flutter.plugin.common.MethodChannel.invokeMethod(MethodChannel.java:120)
E/FileObserver(13147): 	at io.flutter.plugin.common.MethodChannel.invokeMethod(MethodChannel.java:105)
E/FileObserver(13147): 	at id.nizwar.screen_capture_event.ScreenCaptureEventPlugin$1.onEvent(ScreenCaptureEventPlugin.java:99)
E/FileObserver(13147): 	at android.os.FileObserver$ObserverThread.onEvent(FileObserver.java:163)
E/FileObserver(13147): 	at android.os.FileObserver$ObserverThread.observe(Native Method)
E/FileObserver(13147): 	at android.os.FileObserver$ObserverThread.run(FileObserver.java:113)
```