### PR TITLE
fix: Add compatibility with AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,12 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    // Conditional for compatibility with AGP <4.2.
+    compileSdkVersion 30
+
     if (project.android.hasProperty("namespace")) {
         namespace 'id.nizwar.screen_capture_event'
     }
-
-    compileSdkVersion 30
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'id.nizwar.screen_capture_event'
+    }
+
     compileSdkVersion 30
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="id.nizwar.screen_capture_event">
+    xmlns:tools="http://schemas.android.com/tools">
     <application android:requestLegacyExternalStorage="true"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
         tools:ignore="ManifestOrder" />

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
To use this fix now, put this in your `pubspec.yaml`:
```
screen_capture_event:
  git:
    url: https://github.com/stikkyapp/screen_capture_event
    ref: 3de73e6dabcb70a5aacbb5f08395bf31a5a31747
```