### PR TITLE
Fix Android 16 main-thread ANR and Android 13+ media permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.2.1
+* Fix Android 16 main-thread deadlock/ANR: all filesystem scanning and FileObserver
+  setup now run on a background ExecutorService instead of the main thread.
+* Request `READ_MEDIA_IMAGES` on Android 13+ (TIRAMISU), falling back to
+  `READ_EXTERNAL_STORAGE` on older versions.
+* Every MethodChannel call now returns a result so Dart futures never hang.
+* `getLastModified()` guards directory access, filters to readable files, caps the
+  scan at 200 files with a partial mtime sort, and handles `SecurityException`.
+* Bump SDK constraint to Dart 3 (`>=3.0.0 <4.0.0`).
+
 ## 1.1.1
 * Fix Exception when addScreenShotListener (Android) Thanks to @juarezfranco
 ## 1.1.0

--- a/android/src/main/java/id/nizwar/screen_capture_event/ScreenCaptureEventPlugin.java
+++ b/android/src/main/java/id/nizwar/screen_capture_event/ScreenCaptureEventPlugin.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -31,10 +33,12 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
-import android.util.Log;
-
 /**
  * ScreenCaptureEventPlugin
+ *
+ * Performs all filesystem scanning and FileObserver setup off the main thread to
+ * avoid the main-thread deadlock / ANR seen on Android 16, and uses the correct
+ * media permission on Android 13+ (READ_MEDIA_IMAGES).
  */
 public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware {
     static int SCREEN_CAPTURE_PERMISSION = 101;
@@ -43,10 +47,12 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
     private Timer timeout = new Timer();
     private final Map<String, FileObserver> watchModifier = new HashMap<>();
     private ActivityPluginBinding activityPluginBinding;
-    private Handler handler;
+    private Handler handler = new Handler(Looper.getMainLooper());
     private boolean screenRecording = false;
     private long tempSize = 0;
 
+    // Executor to run heavy I/O work on a background thread.
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
@@ -54,10 +60,8 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
         channel.setMethodCallHandler(this);
     }
 
-
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-
         switch (call.method) {
             case "prevent_screenshot":
                 if ((boolean) call.arguments) {
@@ -65,18 +69,24 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
                 } else {
                     activityPluginBinding.getActivity().getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
                 }
+                result.success(null);
                 break;
             case "isRecording":
                 result.success(screenRecording);
                 break;
             case "request_permission":
-                if (ContextCompat.checkSelfPermission(activityPluginBinding.getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-                    ActivityCompat.requestPermissions(activityPluginBinding.getActivity(), new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 101);
+                String permission = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                        ? Manifest.permission.READ_MEDIA_IMAGES
+                        : Manifest.permission.READ_EXTERNAL_STORAGE;
+
+                if (ContextCompat.checkSelfPermission(activityPluginBinding.getActivity(), permission) != PackageManager.PERMISSION_GRANTED) {
+                    ActivityCompat.requestPermissions(activityPluginBinding.getActivity(), new String[]{permission}, 101);
                 }
+                result.success(null);
                 break;
             case "watch":
-                handler = new Handler(Looper.getMainLooper());
-                updateScreenRecordStatus();
+                // Run the initial scan on a background thread to avoid freezing the app.
+                executor.execute(this::updateScreenRecordStatus);
 
                 if (Build.VERSION.SDK_INT >= 29) {
                     final List<File> files = new ArrayList<>();
@@ -88,74 +98,57 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
                     fileObserver = new FileObserver(files) {
                         @Override
                         public void onEvent(int event, final String filename) {
-                            for (String fullPath : paths) {
-                                File file = new File(fullPath + filename);
-                                if (file.exists()) {
-                                    String mime = getMimeType(file.getPath());
-                                    if (mime != null) {
-                                        if (event == FileObserver.CREATE || event == FileObserver.MODIFY) {
-                                            if (mime.contains("video")) {
-                                                setScreenRecordStatus(true);
-                                                updateScreenRecordStatus();
-                                            } else if (mime.contains("image")) {
-                                                handler.post(() -> {
-                                                    channel.invokeMethod("screenshot", file.getPath());
-                                                });
-                                            }
-                                        }else{
-                                            if (mime.contains("video")) {
-                                                stopAllRecordWatcher();
-                                                setScreenRecordStatus(false);
-                                                updateScreenRecordStatus();
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            }
+                            if (filename == null) return;
+                            executor.execute(() -> handleFileEvent(event, filename, paths));
+                        }
                     };
-                    fileObserver.startWatching();
                 } else {
+                    // Logic for older Android versions.
                     for (final Path path : Path.values()) {
                         fileObserver = new FileObserver(path.getPath()) {
                             @Override
                             public void onEvent(int event, final String filename) {
-                                File file = new File(path.getPath() + filename);
-                                if (file.exists()) {
-                                    String mime = getMimeType(file.getPath());
-                                    if (mime != null) {
-                                        if (event == FileObserver.CREATE || event == FileObserver.MODIFY) {
-                                            if (mime.contains("video")) {
-                                                setScreenRecordStatus(true);
-                                                updateScreenRecordStatus();
-                                            } else if (mime.contains("image")) {
-                                                handler.post(() -> {
-                                                    channel.invokeMethod("screenshot", file.getPath());
-                                                });
-                                            }
-                                        }else{
-                                            if (mime.contains("video")) {
-                                                stopAllRecordWatcher();
-                                                setScreenRecordStatus(false);
-                                                updateScreenRecordStatus();
-                                            }
-                                        }
-                                    }
-                                }
+                                if (filename == null) return;
+                                List<String> p = new ArrayList<>();
+                                p.add(path.getPath());
+                                executor.execute(() -> handleFileEvent(event, filename, p));
                             }
                         };
-                        fileObserver.startWatching();
                     }
                 }
+                if (fileObserver != null) fileObserver.startWatching();
+                result.success(null);
                 break;
             case "dispose":
                 if (fileObserver != null) fileObserver.stopWatching();
-                for (Map.Entry<String, FileObserver> stringObjectEntry : watchModifier.entrySet()) {
-                    stringObjectEntry.getValue().stopWatching();
-                }
-                watchModifier.clear();
+                stopAllRecordWatcher();
+                result.success(null);
                 break;
             default:
+                result.notImplemented();
+        }
+    }
+
+    private void handleFileEvent(int event, String filename, List<String> paths) {
+        for (String fullPath : paths) {
+            File file = new File(fullPath + filename);
+            if (file.exists()) {
+                String mime = getMimeType(file.getPath());
+                if (mime != null) {
+                    if (event == FileObserver.CREATE || event == FileObserver.MODIFY) {
+                        if (mime.contains("video")) {
+                            setScreenRecordStatus(true);
+                            updateScreenRecordStatus();
+                        } else if (mime.contains("image")) {
+                            handler.post(() -> channel.invokeMethod("screenshot", file.getPath()));
+                        }
+                    } else {
+                        if (mime.contains("video")) {
+                            stopAllRecordWatcher();
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -168,72 +161,65 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
     }
 
     private void updateScreenRecordStatus() {
-        List<String> paths = new ArrayList<>();
+        // Runs entirely on the executor.
         for (Path path : Path.values()) {
-            paths.add(path.getPath());
-        }
-        for (int i = 0; i < paths.size(); i++) {
-            String fullPath = paths.get(i);
-            File newFile = getLastModified(fullPath);
+            File newFile = getLastModified(path.getPath());
             if (newFile != null) {
                 String mime = getMimeType(newFile.getPath());
-                if (mime != null) {
-                    if (mime.contains("video") && !watchModifier.containsKey(newFile.getPath())) {
-                        FileObserver fileObserver;
-                        if (android.os.Build.VERSION.SDK_INT >= 29) {
-                            fileObserver = new FileObserver(newFile) {
+                if (mime != null && mime.contains("video") && !watchModifier.containsKey(newFile.getPath())) {
+                    handler.post(() -> {
+                        FileObserver fo;
+                        if (Build.VERSION.SDK_INT >= 29) {
+                            fo = new FileObserver(newFile) {
                                 @Override
-                                public void onEvent(int event, @Nullable String path) {
+                                public void onEvent(int event, @Nullable String p) {
                                     handleUpdateScreenRecordEvent(event, newFile);
                                 }
                             };
                         } else {
-                            fileObserver = new FileObserver(newFile.getPath()) {
+                            fo = new FileObserver(newFile.getPath()) {
                                 @Override
-                                public void onEvent(int event, @Nullable String path) {
+                                public void onEvent(int event, @Nullable String p) {
                                     handleUpdateScreenRecordEvent(event, newFile);
                                 }
                             };
                         }
-                        watchModifier.put(newFile.getPath(), fileObserver);
-
-                        FileObserver watch = watchModifier.get(newFile.getPath());
-                        if (watch != null) watch.startWatching();
-                    }
+                        watchModifier.put(newFile.getPath(), fo);
+                        fo.startWatching();
+                    });
                 }
             }
         }
     }
 
     private void handleUpdateScreenRecordEvent(int event, File newFile) {
-        long curSize = newFile.length();
-        if (curSize > tempSize) {
-            if (timeout != null) {
-                try {
-                    timeout.cancel();
-                    timeout = null;
-                } catch (Exception ignored) {
+        executor.execute(() -> {
+            long curSize = newFile.length();
+            if (curSize > tempSize) {
+                if (timeout != null) {
+                    try {
+                        timeout.cancel();
+                    } catch (Exception ignored) {}
                 }
+                setScreenRecordStatus(event == FileObserver.MODIFY);
+                tempSize = curSize;
             }
-            setScreenRecordStatus(event == FileObserver.MODIFY);
-            tempSize = newFile.length();
-        }
-        if (timeout == null) {
+
             timeout = new Timer();
             timeout.schedule(new TimerTask() {
                 @Override
                 public void run() {
                     if (watchModifier.containsKey(newFile.getPath())) {
-                        setScreenRecordStatus(curSize != tempSize);
+                        setScreenRecordStatus(newFile.length() != tempSize);
                     }
                 }
             }, 1500);
-        }
+        });
     }
 
     void setScreenRecordStatus(boolean value) {
         if (screenRecording != value) {
-            new Handler(Looper.getMainLooper()).post(() -> {
+            handler.post(() -> {
                 screenRecording = value;
                 channel.invokeMethod("screenrecord", value);
             });
@@ -242,57 +228,101 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        executor.shutdown();
     }
+
     public static String getMimeType(String url) {
- 
-        // Validate extension
         int lastDotIndex = url.lastIndexOf('.');
         if (lastDotIndex >= 0 && lastDotIndex < url.length() - 1) {
             String extension = url.substring(lastDotIndex + 1);
             return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-
         }
-
         return null;
     }
-    public static File getLastModified(String directoryFilePath) {
-        File directory = new File(directoryFilePath);
-        if (directory.listFiles() == null) return null;
-        File[] files = directory.listFiles(File::isFile);
-        long lastModifiedTime = Long.MIN_VALUE;
-        File chosenFile = null;
 
-        if (files != null) {
-            for (File file : files) {
-                if (file.lastModified() > lastModifiedTime) {
-                    chosenFile = file;
-                    lastModifiedTime = file.lastModified();
+    public static File getLastModified(String directoryFilePath) {
+        try {
+            File directory = new File(directoryFilePath);
+
+            // Verify the directory exists and is readable.
+            if (!directory.exists() || !directory.isDirectory() || !directory.canRead()) {
+                return null;
+            }
+
+            // Use a FileFilter to collect only readable files and reduce overhead.
+            File[] files = directory.listFiles(new java.io.FileFilter() {
+                @Override
+                public boolean accept(File file) {
+                    return file.isFile() && file.canRead();
+                }
+            });
+
+            if (files == null || files.length == 0) {
+                return null;
+            }
+
+            // Cap the number of files scanned to avoid freezing when a folder has many files.
+            int maxFilesToCheck = Math.min(files.length, 200);
+
+            // When there are many files, partially sort so the newest are prioritized.
+            // Only sort as many as needed to avoid wasting time.
+            if (files.length > 50) {
+                // Use Arrays.sort with a comparator to sort by lastModified descending.
+                java.util.Arrays.sort(files, 0, Math.min(files.length, 100),
+                    (f1, f2) -> {
+                        try {
+                            long time1 = f1.lastModified();
+                            long time2 = f2.lastModified();
+                            return Long.compare(time2, time1); // descending
+                        } catch (Exception e) {
+                            return 0;
+                        }
+                    });
+            }
+
+            long lastModifiedTime = Long.MIN_VALUE;
+            File chosenFile = null;
+
+            // Scan the capped set of files, preferring the sorted ones.
+            for (int i = 0; i < maxFilesToCheck; i++) {
+                File file = files[i];
+                try {
+                    long modifiedTime = file.lastModified();
+                    if (modifiedTime > lastModifiedTime) {
+                        chosenFile = file;
+                        lastModifiedTime = modifiedTime;
+                    }
+                } catch (Exception e) {
+                    // Skip a problematic file and continue.
+                    continue;
                 }
             }
-        }
 
-        return chosenFile;
+            return chosenFile;
+        } catch (SecurityException e) {
+            // No permission to access the directory.
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @Override
     public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
         activityPluginBinding = binding;
-
     }
 
     @Override
-    public void onDetachedFromActivityForConfigChanges() {
-
-    }
+    public void onDetachedFromActivityForConfigChanges() {}
 
     @Override
     public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
-
+        activityPluginBinding = binding;
     }
 
     @Override
     public void onDetachedFromActivity() {
-
+        activityPluginBinding = null;
     }
 
     public enum Path {
@@ -301,14 +331,7 @@ public class ScreenCaptureEventPlugin implements FlutterPlugin, MethodCallHandle
         PICTURES(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES) + File.separator + "Screenshots" + File.separator);
 
         final private String path;
-
-        public String getPath() {
-            return path;
-        }
-
-        Path(String path) {
-            this.path = path;
-        }
+        public String getPath() { return path; }
+        Path(String path) { this.path = path; }
     }
-
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: screen_capture_event
 description: Catch screen capture (Screenshot & Screen Record) event for Android and iOS
-version: 1.1.1
+version: 1.2.1
 homepage: https://github.com/nizwar/screen_capture_event.git
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.1.1
 homepage: https://github.com/nizwar/screen_capture_event.git
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=2.8.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION

## Summary

On Android, the plugin scanned the screenshots/recordings directories and set up
`FileObserver`s **on the main thread**. On large media folders this blocks the
main thread long enough to trigger an ANR ("Input dispatching timed out"), which
is especially reproducible on Android 16. The permission request also used the
deprecated `READ_EXTERNAL_STORAGE`, which is a no-op on Android 13+ (API 33+),
so screenshot detection silently failed there.

This PR moves all filesystem work off the main thread and fixes the permission
handling, with no change to the public Dart API.

Likely addresses #28 (ANR / "Input dispatching timed out") and #23
(NullPointerException on Android 13).

## Changes

- **Main-thread ANR fix:** all directory scanning and `FileObserver` setup now
  run on a single-thread `ExecutorService`. The main thread is only touched via a
  `Handler` to deliver the `MethodChannel` callbacks.
- **Android 13+ permission:** `request_permission` now requests
  `READ_MEDIA_IMAGES` on `TIRAMISU`+, falling back to `READ_EXTERNAL_STORAGE` on
  older versions.
- **No hung Dart futures:** every `MethodChannel` branch now returns a result
  (`success`/`notImplemented`).
- **Safer directory scan:** `getLastModified()` verifies the directory exists and
  is readable, filters to readable files, caps the scan at 200 files with a
  partial mtime sort, and handles `SecurityException` — avoiding freezes/crashes
  on folders with many files. Null `filename` events are guarded.
- **Lifecycle:** the executor is shut down in `onDetachedFromEngine`.
- Bumped the SDK constraint to Dart 3 (`>=3.0.0 <4.0.0`) so the package resolves
  in current Flutter projects, and bumped the version to `1.2.1` with a CHANGELOG
  entry.

## Compatibility

- **No public API changes** — purely an internal Android rewrite plus the SDK
  constraint bump. iOS and Dart are untouched.

## Testing

- Built and ran in a production Flutter app (Android, `flutter build apk`),
  screenshot and screen-record detection verified working.
- Confirmed the previous main-thread ANR on large screenshot folders no longer
  reproduces.

## Files

- `android/src/main/java/id/nizwar/screen_capture_event/ScreenCaptureEventPlugin.java`
- `pubspec.yaml`
- `CHANGELOG.md`
